### PR TITLE
🐛 FIX: add missing _cache argument

### DIFF
--- a/src/sphinx_pytest/builders.py
+++ b/src/sphinx_pytest/builders.py
@@ -18,7 +18,9 @@ class DoctreeBuilder(DummyBuilder):
     def init(self) -> None:
         self.doctrees: dict[str, nodes.document] = {}
 
-    def write_doctree(self, docname: str, doctree: nodes.document, *, _cache: bool = True) -> None:
+    def write_doctree(
+        self, docname: str, doctree: nodes.document, *, _cache: bool = True
+    ) -> None:
         # save the doctree instead of pickling to disk
         self.doctrees[docname] = doctree
 

--- a/src/sphinx_pytest/builders.py
+++ b/src/sphinx_pytest/builders.py
@@ -18,7 +18,7 @@ class DoctreeBuilder(DummyBuilder):
     def init(self) -> None:
         self.doctrees: dict[str, nodes.document] = {}
 
-    def write_doctree(self, docname: str, doctree: nodes.document) -> None:
+    def write_doctree(self, docname: str, doctree: nodes.document, *, _cache: bool = True) -> None:
         # save the doctree instead of pickling to disk
         self.doctrees[docname] = doctree
 


### PR DESCRIPTION
It's not working with Sphinx 7 because of that.

https://github.com/sphinx-doc/sphinx/pull/11290