### PR TITLE
fix: make DoctreeBuilder.write_doctree compatible with sphinx

### DIFF
--- a/src/sphinx_pytest/builders.py
+++ b/src/sphinx_pytest/builders.py
@@ -18,7 +18,7 @@ class DoctreeBuilder(DummyBuilder):
     def init(self) -> None:
         self.doctrees: dict[str, nodes.document] = {}
 
-    def write_doctree(self, docname: str, doctree: nodes.document) -> None:
+    def write_doctree(self, docname: str, doctree: nodes.document, _cache: bool = True) -> None:
         # save the doctree instead of pickling to disk
         self.doctrees[docname] = doctree
 


### PR DESCRIPTION
Sphinx updated the function signature of Builder.write_doctree in https://github.com/sphinx-doc/sphinx/pull/11290

With sphinx 7, MyST-Parser's tests are failing because of this. This PR fixes it.