### PR TITLE
Update the rendered html output

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -2,7 +2,7 @@ def test_basic(sphinx_doctree):
     result = sphinx_doctree("abc")
     assert (
         result.pformat()
-        == '<document source="<src>/index.rst">\n    <paragraph>\n        abc'
+        == '<document source="<src>/index.rst" translation_progress="{\'total\': 0, \'translated\': 0}">\n    <paragraph>\n        abc'
     )
 
 
@@ -27,7 +27,7 @@ def test_with_transforms(sphinx_doctree):
     assert (
         result.pformat()
         == """\
-<document source="<src>/index.rst">
+<document source="<src>/index.rst" translation_progress="{\'total\': 0, \'translated\': 0}">
     <target refid="target">
     <section ids="header target" names="header target">
         <title>
@@ -41,6 +41,6 @@ def test_html_builder(sphinx_doctree):
     result = sphinx_doctree(".. only:: html\n\n   abc\n\n.. only:: latex\n\n   xyz\n")
     assert (
         result.get_resolved_pformat()
-        == '<document source="<src>/index.rst">\n    <paragraph>\n        abc'
+        == '<document source="<src>/index.rst" translation_progress="{\'total\': 0, \'translated\': 0}">\n    <paragraph>\n        abc'
         '\n    <comment xml:space="preserve">'
     )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -2,7 +2,7 @@ def test_basic(sphinx_doctree):
     result = sphinx_doctree("abc")
     assert (
         result.pformat()
-        == '<document source="<src>/index.rst" translation_progress="{\'total\': 0, \'translated\': 0}">\n    <paragraph>\n        abc'
+        == "<document source=\"<src>/index.rst\" translation_progress=\"{'total': 0, 'translated': 0}\">\n    <paragraph>\n        abc"
     )
 
 
@@ -41,6 +41,6 @@ def test_html_builder(sphinx_doctree):
     result = sphinx_doctree(".. only:: html\n\n   abc\n\n.. only:: latex\n\n   xyz\n")
     assert (
         result.get_resolved_pformat()
-        == '<document source="<src>/index.rst" translation_progress="{\'total\': 0, \'translated\': 0}">\n    <paragraph>\n        abc'
+        == "<document source=\"<src>/index.rst\" translation_progress=\"{'total': 0, 'translated': 0}\">\n    <paragraph>\n        abc"
         '\n    <comment xml:space="preserve">'
     )


### PR DESCRIPTION
Sphinx 7 added a new property to the HTML output: translation_progress. The tests should pass again when the expected output matches the produced pages.