### PR TITLE
fix: pass in `pathlib.Path` for Sphinx>=7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 keywords = ["sphinx", "pytest"]
 requires-python = ">=3.7"
-dependencies = ["sphinx", "pytest"]
+dependencies = ["sphinx", "pytest", "packaging"]
 
 [project.urls]
 Homepage = "https://github.com/chrisjsewell/sphinx-pytest"

--- a/src/sphinx_pytest/plugin.py
+++ b/src/sphinx_pytest/plugin.py
@@ -5,10 +5,13 @@ from collections.abc import Mapping
 import os
 from pathlib import Path
 from typing import Any, Iterator
+from packaging.version import Version
 
 from docutils import nodes
 from docutils.core import Publisher
 import pytest
+
+import sphinx
 from sphinx.environment import BuildEnvironment
 from sphinx.testing.path import path
 from sphinx.testing.util import SphinxTestApp
@@ -16,6 +19,8 @@ from sphinx.testing.util import SphinxTestApp
 from .builders import DoctreeBuilder
 
 pytest_plugins = ("sphinx.testing.fixtures",)
+
+SPHINX_VERSION = Version(sphinx.__version__)
 
 
 @pytest.fixture
@@ -143,7 +148,7 @@ class CreateDoctree:
 
         return AppWrapper(
             self._app_cls(
-                srcdir=path(str(self.srcdir)),
+                srcdir=self.srcdir if SPHINX_VERSION >= Version("7.0.0") else path(str(self.srcdir)),
                 buildername=self.buildername,
                 confoverrides=self._confoverrides,
                 **kwargs,

--- a/src/sphinx_pytest/plugin.py
+++ b/src/sphinx_pytest/plugin.py
@@ -5,12 +5,11 @@ from collections.abc import Mapping
 import os
 from pathlib import Path
 from typing import Any, Iterator
-from packaging.version import Version
 
 from docutils import nodes
 from docutils.core import Publisher
+from packaging.version import Version
 import pytest
-
 import sphinx
 from sphinx.environment import BuildEnvironment
 from sphinx.testing.path import path
@@ -148,7 +147,9 @@ class CreateDoctree:
 
         return AppWrapper(
             self._app_cls(
-                srcdir=self.srcdir if SPHINX_VERSION >= Version("7.0.0") else path(str(self.srcdir)),
+                srcdir=self.srcdir
+                if SPHINX_VERSION >= Version("7.0.0")
+                else path(str(self.srcdir)),
                 buildername=self.buildername,
                 confoverrides=self._confoverrides,
                 **kwargs,


### PR DESCRIPTION
@chrisjsewell this should fix #19 and #18, which is the issue that (partly) breaks the CI in `myst-parser`.